### PR TITLE
set og url and image for detail page

### DIFF
--- a/server/models/appinfo.go
+++ b/server/models/appinfo.go
@@ -1,8 +1,6 @@
 package models
 
 import (
-	"fmt"
-	"math/rand"
 	"time"
 
 	"strings"
@@ -42,8 +40,7 @@ func (a AppInfo) FirstImageURL() string {
 	if len(a.ImageURLs) > 0 {
 		return a.ImageURLs[0].URL // TODO: とりあえず1件目をメインの画像にする
 	} else {
-		// set default image with random
-		return fmt.Sprintf("/img/no_img/no_img_%d.png", rand.Intn(5))
+		return ""
 	}
 }
 

--- a/server/views/about.go
+++ b/server/views/about.go
@@ -12,6 +12,6 @@ func init() {
 }
 
 func About(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	preload := NewHeader(ctx, "About", "", "", false)
+	preload := NewHeader(ctx, "About", "", "", false, "", "")
 	ExecuteTemplate(ctx, w, r, "about", preload)
 }

--- a/server/views/app.go
+++ b/server/views/app.go
@@ -89,6 +89,8 @@ func AppList(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		"",
 		"気になるアプリ開発に参加しよう",
 		false,
+		"",
+		"",
 	)
 
 	// ViewModel変換して詰める
@@ -127,6 +129,9 @@ func AppDetail(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		appInfo.Description,
 		appInfo.Name,
 		false,
+		// set current relative URL
+		r.URL.RequestURI(),
+		appInfo.MainImage,
 	)
 	preload.AppInfo = NewAppInfoView(ctx, appInfo)
 
@@ -145,6 +150,8 @@ func AppRegister(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		"",
 		"アプリを登録して仲間を探そう",
 		false,
+		"",
+		"",
 	)
 
 	// 自分をデフォルトメンバーとして突っ込んでおく
@@ -186,6 +193,8 @@ func AppEdit(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		"",
 		"アプリを登録して仲間を探そう",
 		false,
+		"",
+		"",
 	)
 	// sizeを3にする
 	if len(appInfo.ImageURLs) != 3 {

--- a/server/views/app_logic.go
+++ b/server/views/app_logic.go
@@ -2,8 +2,10 @@ package views
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"time"
 
 	"github.com/go-xweb/uuid"
@@ -47,6 +49,10 @@ func convertRegisterAppInfo(ctx context.Context, appInfo models.AppInfo) models.
 
 	// メインの画像を設定
 	appInfo.MainImage = appInfo.FirstImageURL()
+	if(appInfo.MainImage == "") {
+		// set default image with random
+		appInfo.MainImage = StaticPath() + fmt.Sprintf("/img/no_img/no_img_%d.png", rand.Intn(5))
+	}
 
 	return appInfo
 }

--- a/server/views/contact.go
+++ b/server/views/contact.go
@@ -12,6 +12,6 @@ func init() {
 }
 
 func Constact(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	preload := NewHeader(ctx, "Constact", "", "", false)
+	preload := NewHeader(ctx, "Constact", "", "", false, "", "")
 	ExecuteTemplate(ctx, w, r, "contact", preload)
 }

--- a/server/views/error.go
+++ b/server/views/error.go
@@ -18,7 +18,7 @@ func Error(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 }
 
 func executeError(ctx context.Context, w http.ResponseWriter, r *http.Request, err error) {
-	preload := NewHeader(ctx, "Error", "", "", false)
+	preload := NewHeader(ctx, "Error", "", "", false, "", "")
 
 	if err != nil {
 		log.Println("ERROR!", err)

--- a/server/views/index.go
+++ b/server/views/index.go
@@ -34,6 +34,8 @@ func Index(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		"",
 		"一緒にアプリを開発する仲間を探そう",
 		true,
+		"",
+		"",
 	)
 	preload.LastedList = latestList
 	preload.PopularList = popularList

--- a/server/views/login.go
+++ b/server/views/login.go
@@ -28,7 +28,7 @@ func Login(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	preload := NewHeader(ctx, "Login", "", "", false)
+	preload := NewHeader(ctx, "Login", "", "", false, "", "")
 	ExecuteTemplate(ctx, w, r, "login", preload)
 }
 

--- a/server/views/mypage.go
+++ b/server/views/mypage.go
@@ -50,7 +50,7 @@ func Mypage(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	preload := MyPageResponse{}
 	preload.User = user
-	preload.TemplateHeader = NewHeader(ctx, "マイページ", "", "", false)
+	preload.TemplateHeader = NewHeader(ctx, "マイページ", "", "", false, "", "",)
 
 	adminApps, _ := models.AppsInfoTable.FindByAdminID(ctx, a.UserID)
 	joinApps, _ := models.AppsInfoTable.FindByJoinID(ctx, a.UserID)
@@ -76,7 +76,7 @@ func MypageOther(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	preload := MyPageResponse{}
 	preload.User = user
-	preload.TemplateHeader = NewHeader(ctx, user.Name, "", "", false)
+	preload.TemplateHeader = NewHeader(ctx, user.Name, "", "", false, "", "",)
 
 	// loginしている状態のみ他人のページとして自分を見に来たときに管理アイデアを表示
 	adminApps, _ := models.AppsInfoTable.FindByAdminID(ctx, userID)
@@ -105,7 +105,7 @@ func MypageEdit(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	preload := MyPageResponse{}
 	preload.User = user
-	preload.TemplateHeader = NewHeader(ctx, "マイページの編集", "", "", false)
+	preload.TemplateHeader = NewHeader(ctx, "マイページの編集", "", "", false, "", "",)
 
 	ExecuteTemplate(ctx, w, r, "mypageEdit", preload)
 }

--- a/server/views/privacy.go
+++ b/server/views/privacy.go
@@ -12,6 +12,6 @@ func init() {
 }
 
 func Privacy(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	preload := NewHeader(ctx, "Privacy", "", "", false)
+	preload := NewHeader(ctx, "Privacy", "", "", false, "", "")
 	ExecuteTemplate(ctx, w, r, "privacy", preload)
 }

--- a/server/views/render.go
+++ b/server/views/render.go
@@ -19,6 +19,10 @@ import (
 
 var staticPath string
 
+func StaticPath() string {
+	return staticPath
+}
+
 func init() {
 	staticPath = os.Getenv("STATIC_URL")
 }
@@ -34,6 +38,8 @@ type TemplateHeader struct {
 	Description string
 	SubTitle    string
 	ShowBanner  bool
+	OgURL    string
+	OgImageURL    string
 	Config      Config           `json:"config"`
 	Constants   models.Constants `json:"constants"`
 }
@@ -60,7 +66,7 @@ func (t TemplateHeader) FormatTimeToDate(time time.Time) string {
 	return time.Format("2006-01-02")
 }
 
-func NewHeader(ctx context.Context, title, description, subTitle string, showBanner bool) TemplateHeader {
+func NewHeader(ctx context.Context, title, description, subTitle string, showBanner bool, ogURL string, ogImageURL string) TemplateHeader {
 	a, _ := oauth.FromContext(ctx)
 
 	user, _ := models.UsersTable.FindID(ctx, a.UserID)
@@ -70,7 +76,7 @@ func NewHeader(ctx context.Context, title, description, subTitle string, showBan
 	h.Config = Config{}
 	h.Config.User = user
 	h.Config.Notification = nt
-	h.Config.StaticPath = staticPath
+	h.Config.StaticPath = StaticPath()
 
 	h.Constants = models.AllConstants()
 
@@ -78,6 +84,8 @@ func NewHeader(ctx context.Context, title, description, subTitle string, showBan
 	h.SubTitle = subTitle
 	h.Description = description
 	h.ShowBanner = showBanner
+	h.OgURL = ogURL
+	h.OgImageURL = ogImageURL
 
 	return h
 }

--- a/server/views/terms.go
+++ b/server/views/terms.go
@@ -12,6 +12,6 @@ func init() {
 }
 
 func Terms(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	preload := NewHeader(ctx, "Terms", "", "", false)
+	preload := NewHeader(ctx, "Terms", "", "", false, "", "")
 	ExecuteTemplate(ctx, w, r, "terms", preload)
 }

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -5,10 +5,12 @@
 <!-- og:descriptionには Description があればセットする -->
 <meta name="description" content="{{with .Description }}{{ . }}{{else}}MeetAppは趣味でアプリ・サービスの開発をしたいデザイナー・エンジニアと、開発のアイデアを持っている企画者のマッチングサービスです。MeetAppであなたの開発アイデアを実現する仲間を探しましょう。{{end}}">
 <meta property="og:description" content="{{with .Description }}{{ . }}{{else}}MeetAppは趣味でアプリ・サービスの開発をしたいデザイナー・エンジニアと、開発のアイデアを持っている企画者のマッチングサービスです。MeetAppであなたの開発アイデアを実現する仲間を探しましょう。{{end}}">
-<meta name="keywords" content="meetapp, 趣味, 開発, アプリ, サービス, 求人, 企画, エンジニア, デザイナー, hobby, app, development, job, engineer, designer">
+<meta name="keywords" content="meetapp, 趣味, 開発, アプリ, プログラミング, サービス, 求人, 企画, エンジニア, デザイナー, hobby, app, development, job, engineer, designer">
 <meta property="og:title" content="{{ .Title }}">
-<meta property="og:image" content="{{ .Config.StaticPath }}/img/logo_large.png">
-<meta property="og:url" content="https://meetapp.tokyo/">
+<!-- og:image OgImageURL があればセットする (w_160をつけたサイズではFBで200px以下としてerrorになるのでoriginalサイズのURLを指定) -->
+<meta property="og:image" content="{{if .OgImageURL }}{{ .OriginalImage .OgImageURL }}{{else}}{{ .Config.StaticPath }}/img/about_bg1.png{{end}}">
+<!-- og:url OgURL (relative URL) があればセットする -->
+<meta property="og:url" content="https://meetapp.tokyo{{with .OgURL }}{{ . }}{{end}}">
 <meta property="og:type" content="article">
 <meta property="og:site_name" content="MeetApp">
 <link rel="shortcut icon" href="/favicon.ico">


### PR DESCRIPTION
Need to set following og properties on detail page.
Originally reported by issue #72 

- og url -> the detail page URL
- og image -> absolute image path for share
