### PR TITLE
views: added POST /markdown/preview

### DIFF
--- a/server/views/markdown.go
+++ b/server/views/markdown.go
@@ -1,0 +1,35 @@
+package views
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"html/template"
+
+	"github.com/guregu/kami"
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/russross/blackfriday"
+	"golang.org/x/net/context"
+)
+
+func init() {
+	kami.Post("/markdown/preview", MarkdownPreview)
+}
+
+func MarkdownPreview(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Println("ERROR!", err)
+		renderer.JSON(w, 400, err.Error())
+		return
+	}
+
+	log.Println(string(data))
+
+	safe := template.HTMLEscapeString(string(data))
+	unsafe := blackfriday.MarkdownCommon([]byte(safe))
+	markdown := template.HTML(string(bluemonday.UGCPolicy().SanitizeBytes(unsafe)))
+
+	renderer.Data(w, 200, []byte(markdown))
+}


### PR DESCRIPTION
https://trello.com/c/klpla8n7/45-markdown-preview

の対応

```
$ echo "# hoge
## fuga" | http POST http://localhost:8000/markdown/preview
```

```
HTTP/1.1 200 OK
Content-Length: 29
Content-Type: application/octet-stream
Date: Sun, 05 Jul 2015 03:09:48 GMT

<h1>hoge</h1>

<h2>fuga</h2>
```